### PR TITLE
handle type-casting for config, even when explicitly setting values using .set method

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -196,14 +196,7 @@ module Hutch
       env_keys_configured.each_with_object({}) {|attr, result|
         value = ENV[key_for(attr)]
 
-        case
-        when is_bool(attr) || value == 'false'
-          result[attr] = to_bool(value)
-        when is_num(attr)
-          result[attr] = value.to_i
-        else
-          result[attr] = value
-        end
+        result[attr] = type_cast(attr, value)
       }
     end
 
@@ -238,7 +231,7 @@ module Hutch
 
     def self.set(attr, value)
       check_attr(attr.to_sym)
-      user_config[attr.to_sym] = value
+      user_config[attr.to_sym] = type_cast(attr, value)
     end
 
     class << self
@@ -274,6 +267,18 @@ module Hutch
         value
       end
     end
+
+    def self.type_cast(attr, value)
+      case
+      when is_bool(attr) || value == 'false'
+        to_bool(value)
+      when is_num(attr)
+        value.to_i
+      else
+        value
+      end
+    end
+    private_class_method :type_cast
 
     def self.define_methods
       @config.keys.each do |key|

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -49,6 +49,44 @@ describe Hutch::Config do
       context 'sets value in user config hash' do
         it { is_expected.to eq(new_value) }
       end
+
+      context 'type casting' do
+        context 'number attributes' do
+          before  { Hutch::Config.set(:heartbeat, new_value) }
+          subject(:value) { Hutch::Config.user_config[:heartbeat] }
+
+          let(:new_value) { "0" }
+
+
+          specify 'casts values to integers' do
+            expect(value).to eq 0
+          end
+        end
+      end
+
+      context 'boolean attributes' do
+        before  { Hutch::Config.set(:autoload_rails, new_value) }
+        subject(:value) { Hutch::Config.user_config[:autoload_rails] }
+
+        let(:new_value) { "t" }
+
+
+        specify 'casts values to booleans' do
+          expect(value).to eq true
+        end
+      end
+
+      context 'string attributes' do
+        before  { Hutch::Config.set(:mq_exchange_type, new_value) }
+        subject(:value) { Hutch::Config.user_config[:mq_exchange_type] }
+
+        let(:new_value) { 1 }
+
+
+        specify 'does not perform any type' do
+          expect(value).to eq new_value
+        end
+      end
     end
 
     context 'for invalid attributes' do

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -83,7 +83,7 @@ describe Hutch::Config do
         let(:new_value) { 1 }
 
 
-        specify 'does not perform any type' do
+        specify 'does not perform any typecasting' do
           expect(value).to eq new_value
         end
       end


### PR DESCRIPTION
I had a pretty unfortunate issue when directly setting the config value for `heartbeat` without an explicit typecasting: `Hutch::Config.set(:heartbeat, ENV.fetch("HUTCH_HEARTBEAT", 30))` but the ENV var was obviously a string and it caused some failures when publishing messages. Since the type is explicitly declared on a config level, I believe the desired behaviour would be to handle type-casting inside `set` method as well. 