### PR TITLE
CI: Use latest 9.2 JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
     - rvm: "2.5.8"
     - rvm: "2.4.10"
     - rvm: "2.3.8"
-    - rvm: "jruby-9.2.9.0"
+    - rvm: "jruby-9.2.15.0"
     - rvm: "ruby-head"
   allow_failures:
     rvm:
-      - "jruby-9.2.9.0"
+      - "jruby-9.2.15.0"
       - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
     - rvm: "2.5.8"
     - rvm: "2.4.10"
     - rvm: "2.3.8"
-    - rvm: "jruby-9.2.15.0"
+    - rvm: "jruby-9.2.16.0"
     - rvm: "ruby-head"
   allow_failures:
     rvm:
-      - "jruby-9.2.15.0"
+      - "jruby-9.2.16.0"
       - ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)