### PR TITLE
CI: Configure JRuby 9.2.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - rvm: "2.7.1"
     - rvm: "2.6.6"
     - rvm: "2.5.8"
-    - rvm: "jruby-9.2.18.0"
+    - rvm: "jruby-9.2.19.0"
       name: "Latest JRuby"
     - rvm: "ruby-head"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
     - rvm: "2.7.1"
     - rvm: "2.6.6"
     - rvm: "2.5.8"
-    - rvm: "jruby-9.2.16.0"
+    - rvm: "jruby-9.2.18.0"
+      name: "Latest JRuby"
     - rvm: "ruby-head"
   allow_failures:
-    rvm:
-      - "jruby-9.2.16.0"
-      - ruby-head
+    - name: "Latest JRuby"
+    - rvm: ruby-head


### PR DESCRIPTION
Try using a named entry to be able to easier match it.

This PR updates the CI matrix to use latest JRuby, **9.2.19.0**.

[JRuby 9.2.19.0 release blog post](https://www.jruby.org/2021/06/15/jruby-9-2-19-0.html)