### PR TITLE
Make Bunny all queue options available

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -171,11 +171,11 @@ module Hutch
     end
 
     # Create / get a durable queue and apply namespace if it exists.
-    def queue(name, arguments = {})
+    def queue(name, options = {})
       with_bunny_precondition_handler('queue') do
         namespace = @config[:namespace].to_s.downcase.gsub(/[^-_:\.\w]/, "")
         name = name.prepend(namespace + ":") if namespace.present?
-        channel.queue(name, durable: true, arguments: arguments)
+        channel.queue(name, **options)
       end
     end
 

--- a/lib/hutch/consumer.rb
+++ b/lib/hutch/consumer.rb
@@ -65,6 +65,11 @@ module Hutch
         @arguments = arguments
       end
 
+      # Congfiures queue options that will be passed when declaring the queue.
+      def queue_options(options = {})
+        @queue_options = options
+      end
+
       # Set custom serializer class, override global value
       def serializer(name)
         @serializer = name
@@ -89,6 +94,15 @@ module Hutch
         all_arguments['x-quorum-initial-group-size'] = @initial_group_size if @initial_group_size
 
         all_arguments
+      end
+
+      def get_options
+        default_options = { durable: true }
+
+        all_options = default_options.merge(@queue_options || {})
+        all_options[:arguments] = get_arguments
+
+        all_options
       end
 
       # Accessor for the consumer's routing key.

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -47,7 +47,7 @@ module Hutch
     def setup_queue(consumer)
       logger.info "setting up queue: #{consumer.get_queue_name}"
 
-      queue = @broker.queue(consumer.get_queue_name, consumer.get_arguments)
+      queue = @broker.queue(consumer.get_queue_name, consumer.get_options)
       @broker.bind_queue(queue, consumer.routing_keys)
 
       queue.subscribe(consumer_tag: unique_consumer_tag, manual_ack: true) do |*args|

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -262,7 +262,7 @@ describe Hutch::Broker do
         args.first == ''
         args.last == arguments
       end
-      broker.queue('test', arguments)
+      broker.queue('test', arguments: arguments)
     end
   end
 

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -4,7 +4,7 @@ require 'hutch/worker'
 describe Hutch::Worker do
   let(:consumer) { double('Consumer', routing_keys: %w( a b c ),
                           get_queue_name: 'consumer', get_arguments: {},
-                          get_serializer: nil) }
+                          get_options: {}, get_serializer: nil) }
   let(:consumers) { [consumer, double('Consumer')] }
   let(:broker) { Hutch::Broker.new }
   let(:setup_procs) { Array.new(2) { Proc.new {} } }
@@ -35,7 +35,7 @@ describe Hutch::Worker do
     before { allow(broker).to receive_messages(queue: queue, bind_queue: nil) }
 
     it 'creates a queue' do
-      expect(broker).to receive(:queue).with(consumer.get_queue_name, consumer.get_arguments).and_return(queue)
+      expect(broker).to receive(:queue).with(consumer.get_queue_name, consumer.get_options).and_return(queue)
       worker.setup_queue(consumer)
     end
 


### PR DESCRIPTION
want to make use of bunny queue options, e.g. disallow application to create queue by setting `no_declare: true`