### PR TITLE
Fix warning about usage of TrueClass#=~ on Ruby 2.7

### DIFF
--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -222,7 +222,12 @@ module Hutch
     end
 
     def self.to_bool(value)
-      !(value.nil? || value == '' || value =~ /^(false|f|no|n|0)$/i || value == false)
+      case value
+      when nil, false, '', /^(false|f|no|n|0)$/i
+        false
+      else
+        true
+      end
     end
 
     def self.is_num(attr)

--- a/spec/hutch/config_spec.rb
+++ b/spec/hutch/config_spec.rb
@@ -65,14 +65,52 @@ describe Hutch::Config do
       end
 
       context 'boolean attributes' do
-        before  { Hutch::Config.set(:autoload_rails, new_value) }
-        subject(:value) { Hutch::Config.user_config[:autoload_rails] }
+        context 'from non-empty string' do
+          before  { Hutch::Config.set(:autoload_rails, new_value) }
+          subject(:value) { Hutch::Config.user_config[:autoload_rails] }
 
-        let(:new_value) { "t" }
+          let(:new_value) { "t" }
 
 
-        specify 'casts values to booleans' do
-          expect(value).to eq true
+          specify 'casts values to booleans' do
+            expect(value).to eq true
+          end
+        end
+
+        context 'from empty string' do
+          before  { Hutch::Config.set(:autoload_rails, new_value) }
+          subject(:value) { Hutch::Config.user_config[:autoload_rails] }
+
+          let(:new_value) { "" }
+
+
+          specify 'casts values to booleans' do
+            expect(value).to eq false
+          end
+        end
+
+        context 'from boolean' do
+          before  { Hutch::Config.set(:autoload_rails, new_value) }
+          subject(:value) { Hutch::Config.user_config[:autoload_rails] }
+
+          let(:new_value) { true }
+
+
+          specify 'casts values to booleans' do
+            expect(value).to eq true
+          end
+        end
+
+        context 'from nil' do
+          before  { Hutch::Config.set(:autoload_rails, new_value) }
+          subject(:value) { Hutch::Config.user_config[:autoload_rails] }
+
+          let(:new_value) { nil }
+
+
+          specify 'casts values to booleans' do
+            expect(value).to eq false
+          end
         end
       end
 


### PR DESCRIPTION
This fixes a warning raised by Ruby 2.7 when attempting to check a
boolean against a regexp:

    .../lib/hutch/config.rb:225: warning: deprecated Object#=~ is called on TrueClass; it always returns nil