### PR TITLE
Fix $LOAD_PATH error

### DIFF
--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -65,7 +65,7 @@ module Hutch
           return false
         ensure
           # Clean up load path
-          $LOAD_PATH.pop
+          $LOAD_PATH.delete('.')
         end
       end
     end


### PR DESCRIPTION
Fixes a bug with requiring components.

Example: https://github.com/AlexanderMint/hutch_example_error

If an executable file has paths added to $LOAD_PATH, then the last path added by the user will be removed