### PR TITLE
Do not modify queue name in place. Create a new String

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -174,8 +174,8 @@ module Hutch
     def queue(name, options = {})
       with_bunny_precondition_handler('queue') do
         namespace = @config[:namespace].to_s.downcase.gsub(/[^-_:\.\w]/, "")
-        name = name.prepend(namespace + ":") if namespace.present?
-        channel.queue(name, **options)
+        queue_name = namespace.present? ? "#{namespace}:#{name}" : name
+        channel.queue(queue_name, **options)
       end
     end
 

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -262,7 +262,7 @@ describe Hutch::Broker do
         args.first == ''
         args.last == arguments
       end
-      broker.queue('test', arguments: arguments)
+      broker.queue('test'.freeze, arguments: arguments)
     end
   end
 


### PR DESCRIPTION
I regularly include the magic comment, `# frozen_string_literal: true`, in my ruby code.

This results in an error when defining a `queue_name` in a consumer class, since the `Hutch::Broker` class will modify the string instead of creating a new one: `lib/hutch/broker.rb:177:in 'prepend': can't modify frozen String (FrozenError)`