### PR TITLE
fix: reject and requeue double acknowledgement

### DIFF
--- a/lib/hutch/consumer.rb
+++ b/lib/hutch/consumer.rb
@@ -13,10 +13,12 @@ module Hutch
     end
 
     def reject!
+      @message_rejected = true
       broker.reject(delivery_info.delivery_tag)
     end
 
     def requeue!
+      @message_rejected = true
       broker.requeue(delivery_info.delivery_tag)
     end
 

--- a/lib/hutch/consumer.rb
+++ b/lib/hutch/consumer.rb
@@ -22,6 +22,10 @@ module Hutch
       broker.requeue(delivery_info.delivery_tag)
     end
 
+    def message_rejected?
+      !!@message_rejected
+    end
+
     def logger
       Hutch::Logging.logger
     end

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -71,7 +71,7 @@ module Hutch
       message = Message.new(delivery_info, properties, payload, serializer)
       consumer_instance = consumer.new.tap { |c| c.broker, c.delivery_info = @broker, delivery_info }
       with_tracing(consumer_instance).handle(message)
-      @broker.ack(delivery_info.delivery_tag)
+      @broker.ack(delivery_info.delivery_tag) unless consumer_instance.message_rejected?
     rescue => ex
       acknowledge_error(delivery_info, properties, @broker, ex)
       handle_error(properties, payload, consumer, ex)

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -83,12 +83,14 @@ describe Hutch::Worker do
     it 'passes the message to the consumer' do
       expect(consumer_instance).to receive(:process).
                         with(an_instance_of(Hutch::Message))
+      expect(consumer_instance).to receive(:message_rejected?).and_return(false)
       worker.handle_message(consumer, delivery_info, properties, payload)
     end
 
     it 'acknowledges the message' do
       allow(consumer_instance).to receive(:process)
       expect(broker).to receive(:ack).with(delivery_info.delivery_tag)
+      expect(consumer_instance).to receive(:message_rejected?).and_return(false)
       worker.handle_message(consumer, delivery_info, properties, payload)
     end
 


### PR DESCRIPTION
Fix Issue in (requeue! and reject! )
For Example:
When you are using reject!
1. Will broker.reject(delivery_info.delivery_tag) -> will go to def reject in broker.rb
2. Will call channel.reject(delivery_tag, false)-> will go to bunny reject in channel.rb
3. Will call  basic_reject(delivery_tag.to_i, false) which going to reject the message So it's acknowledged
4. In worker.rb handle_message by default do  @broker.ack(delivery_info.delivery_tag) so it's going to be double acknowledged
Solution : 

1. Add Boolean in reject and requeue in broker.rb that message rejected
2. in handle_message before doing default ack check on this boolean