### PR TITLE
Allow auth mechanism to be configured

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -287,6 +287,7 @@ module Hutch
         params[:host]               = @config[:mq_host]
         params[:port]               = @config[:mq_port]
         params[:vhost]              = @config[:mq_vhost].presence || Hutch::Adapter::DEFAULT_VHOST
+        params[:auth_mechanism]     = @config[:mq_auth_mechanism]
         params[:username]           = @config[:mq_username]
         params[:password]           = @config[:mq_password]
         params[:tls]                = @config[:mq_tls]

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -63,6 +63,9 @@ module Hutch
     # RabbitMQ password
     string_setting :mq_password, 'guest'
 
+    # RabbitMQ Auth Mechanism
+    string_setting :mq_auth_mechanism, 'PLAIN'
+
     # RabbitMQ URI (takes precedence over MQ username, password, host, port and vhost settings)
     string_setting :uri, nil
 


### PR DESCRIPTION
Exposes the ability to configure Bunny's `auth_mechanism` parameter, so that TLS certificate authentication may be used.

See http://rubybunny.info/articles/connecting.html for details.