### PR TITLE
exact queue name option

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -173,10 +173,14 @@ module Hutch
     # Create / get a durable queue and apply namespace if it exists.
     def queue(name, options = {})
       with_bunny_precondition_handler('queue') do
-        namespace = @config[:namespace].to_s.downcase.gsub(/[^-_:\.\w]/, "")
-        queue_name = namespace.present? ? "#{namespace}:#{name}" : name
-        channel.queue(queue_name, **options)
+        channel.queue(name, **options)
       end
+    end
+
+    def namespaced_queue_name(name)
+      namespace = @config[:namespace].to_s.downcase.gsub(/[^-_:\.\w]/, "")
+      name = name.prepend(namespace + ":") if namespace.present?
+      name
     end
 
     # Return a mapping of queue names to the routing keys they're bound to.

--- a/lib/hutch/consumer.rb
+++ b/lib/hutch/consumer.rb
@@ -43,7 +43,8 @@ module Hutch
       attr_reader :queue_mode, :queue_type, :initial_group_size
 
       # Explicitly set the queue name
-      def queue_name(name)
+      def queue_name(name, exact: false)
+        @queue_name_exact = exact
         @queue_name = name
       end
 
@@ -89,6 +90,11 @@ module Hutch
         queue_name = self.name.gsub(/::/, ':')
         queue_name.gsub!(/([^A-Z:])([A-Z])/) { "#{$1}_#{$2}" }
         queue_name.downcase
+      end
+
+      # Ask for the queue name to be used verbatim (ignore namespace)
+      def get_queue_name_exact?
+        @queue_name_exact
       end
 
       # Returns consumer custom arguments.

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -45,9 +45,11 @@ module Hutch
     # Bind a consumer's routing keys to its queue, and set up a subscription to
     # receive messages sent to the queue.
     def setup_queue(consumer)
-      logger.info "setting up queue: #{consumer.get_queue_name}"
+      queue_name = consumer.get_queue_name
+      queue_name = @broker.namespaced_queue_name(queue_name) unless consumer.get_queue_name_exact?
+      logger.info "setting up queue: #{queue_name}"
 
-      queue = @broker.queue(consumer.get_queue_name, consumer.get_options)
+      queue = @broker.queue(queue_name, consumer.get_options)
       @broker.bind_queue(queue, consumer.routing_keys)
 
       queue.subscribe(consumer_tag: unique_consumer_tag, manual_ack: true) do |*args|


### PR DESCRIPTION
Sometimes we want to bind to an exact queue name without using the namespace.

For example, for most of our consumers we want to use the application name as a prefix to help group queues. However, we have a global 'deadletter' queue which we do not want to namespace, but connect to verbatim.

This PR allows `exact: true` to be added when setting the queue_name in a consumer.