### PR TITLE
Add delivery_info to properties for error handler

### DIFF
--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -75,7 +75,7 @@ module Hutch
     rescue => ex
       acknowledge_error(delivery_info, properties, @broker, ex)
       properties = Bunny::MessageProperties.new(properties.to_hash.merge(delivery_info: delivery_info))
-      handle_error(properties, payload, consumer, ex)
+      handle_error(properties, payload, consumer, ex, delivery_info)
     end
 
     def with_tracing(klass)
@@ -84,7 +84,7 @@ module Hutch
 
     def handle_error(*args)
       Hutch::Config[:error_handlers].each do |backend|
-        backend.handle(*args)
+        backend.handle *args.first(backend.method(:handle).arity)
       end
     end
 

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -74,7 +74,6 @@ module Hutch
       @broker.ack(delivery_info.delivery_tag) unless consumer_instance.message_rejected?
     rescue => ex
       acknowledge_error(delivery_info, properties, @broker, ex)
-      properties = Bunny::MessageProperties.new(properties.to_hash.merge(delivery_info: delivery_info))
       handle_error(properties, payload, consumer, ex, delivery_info)
     end
 

--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -74,6 +74,7 @@ module Hutch
       @broker.ack(delivery_info.delivery_tag) unless consumer_instance.message_rejected?
     rescue => ex
       acknowledge_error(delivery_info, properties, @broker, ex)
+      properties = Bunny::MessageProperties.new(properties.to_hash.merge(delivery_info: delivery_info))
       handle_error(properties, payload, consumer, ex)
     end
 


### PR DESCRIPTION
When handling an error, it would be useful to know the delivery_info such as the routing key. This adds delivery_info to message properties. This seemed the only way to supply the information without changing the error handler contract.