### PR TITLE
Client properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,13 @@ Generate with
       <td><p>The <tt>basic.qos</tt> prefetch value to use.</p></td>
     </tr>
     <tr>
+      <td><tt>connection_name</tt></td>
+      <td>nil</td>
+      <td>String</td>
+      <td><tt>HUTCH_CONNECTION_NAME</tt></td>
+      <td><p><a href="https://www.rabbitmq.com/docs/connections#client-provided-names">Client-Provided Connection Name</a></p></td>
+    </tr>
+    <tr>
       <td><tt>connection_timeout</tt></td>
       <td>11</td>
       <td>Number</td>

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Known configuration parameters are:
  * `error_acknowledgements`: a chain of responsibility of objects that acknowledge/reject/requeue messages when an
     exception happens, see classes in `Hutch::Acknowledgements`.
  * `mq_exchange`: exchange to use for publishing (default: `hutch`)
+ * `mq_client_properties`: Bunny's [client properties](https://www.rabbitmq.com/docs/connections#capabilities) (default: `{}`)
  * `heartbeat`: [RabbitMQ heartbeat timeout](http://rabbitmq.com/heartbeats.html) (default: `30`)
  * `connection_timeout`: Bunny's socket open timeout (default: `11`)
  * `read_timeout`: Bunny's socket read timeout (default: `11`)

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -298,6 +298,7 @@ module Hutch
           params[:tls_ca_certificates] = @config[:mq_tls_ca_certificates]
         end
         params[:heartbeat]          = @config[:heartbeat]
+        params[:connection_name]    = @config[:connection_name]
         params[:connection_timeout] = @config[:connection_timeout]
         params[:read_timeout]       = @config[:read_timeout]
         params[:write_timeout]      = @config[:write_timeout]

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -298,6 +298,7 @@ module Hutch
           params[:tls_ca_certificates] = @config[:mq_tls_ca_certificates]
         end
         params[:heartbeat]          = @config[:heartbeat]
+        params[:client_properties]  = @config[:mq_client_properties]
         params[:connection_name]    = @config[:connection_name]
         params[:connection_timeout] = @config[:connection_timeout]
         params[:read_timeout]       = @config[:read_timeout]

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -174,6 +174,7 @@ module Hutch
     # @return [Hash]
     def self.default_config
       @settings_defaults.merge({
+        mq_client_properties: {},
         mq_exchange_options: {},
         mq_tls_cert: nil,
         mq_tls_key: nil,

--- a/lib/hutch/config.rb
+++ b/lib/hutch/config.rb
@@ -86,6 +86,9 @@ module Hutch
     # Default: `0`, no limit. See Bunny and RabbitMQ documentation.
     number_setting :channel_prefetch, 0
 
+    # [Client-Provided Connection Name](https://www.rabbitmq.com/docs/connections#client-provided-names)
+    string_setting :connection_name, nil
+
     # Bunny's socket open timeout
     number_setting :connection_timeout, 11
 


### PR DESCRIPTION
Thank you for this project! :heart:

I've noticed an opportunity to enhance observability from the broker's perspective.

Firstly, introducing a feature to set a human-friendly connection name would greatly improve the ability to distinguish connections easily.

Secondly, providing additional information in client properties could be useful in identifying issues with applications, such as the application version.



With this pull request, I propose adding two additional configuration options:

1. `connection_name` - to set the connection name conveniently. It can be easily controlled with the `HUTCH_CONNECTION_NAME` environment variable, requiring no explicit configuration.   
2. `mq_client_properties` - to manage all client properties, including the `connection_name`.
    ```ruby
    Hutch::Config.set :mq_client_properties,
                      connection_name: 'human-friendly-consumer-name',
                      product: 'SomethingCool',
                      version: 'commit-sha',
                      information: 'http://example.com/repo/commits/commit-sha'
    ```
<details>
  <summary>Before</summary>
  
  ![Screenshot from 2024-05-06 20-27-51](https://github.com/ruby-amqp/hutch/assets/1262244/b613a168-882a-4a68-9de2-7502c9004789)
 
  ![Screenshot from 2024-05-06 20-46-05](https://github.com/ruby-amqp/hutch/assets/1262244/80b8e7ab-d0b7-4dea-9609-a8fa5ac469dc)
  
</details>

<details>
  <summary>After</summary>

  ![Screenshot from 2024-05-06 20-55-33](https://github.com/ruby-amqp/hutch/assets/1262244/a12d4c7e-2c51-43ca-9da8-1d35647b612d)
  
  ![Screenshot from 2024-05-06 20-53-58](https://github.com/ruby-amqp/hutch/assets/1262244/2779b7c8-8b66-465e-8687-fc259486bfdc)

</details>