### PR TITLE
Require ostruct explicitly

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/object/blank'
 
 require 'carrot-top'
+require 'ostruct'
 require 'hutch/logging'
 require 'hutch/exceptions'
 require 'hutch/publisher'


### PR DESCRIPTION
`OpenStruct` is optional since `JSON` v 2.7.2

References:
- https://github.com/flori/json/pull/565
- https://github.com/ruby/ostruct/blob/master/lib/ostruct.rb#L136

This commit fixes error:

```
Hutch.connect

gems/hutch-1.2.0/lib/hutch/broker.rb:272:in `api_config': uninitialized constant Hutch::Broker::OpenStruct (NameError)

      @api_config ||= OpenStruct.new.tap do |config|
                      ^^^^^^^^^^
```