### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,7 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
+on: [push,pull_request,workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
+          - 3.2
+          - 3.3
 
     steps:
     - uses: actions/checkout@v3

--- a/spec/hutch/error_handlers/bugsnag_spec.rb
+++ b/spec/hutch/error_handlers/bugsnag_spec.rb
@@ -8,6 +8,7 @@ describe Hutch::ErrorHandlers::Bugsnag do
   before do
     Bugsnag.configure do |bugsnag|
       bugsnag.api_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      bugsnag.logger = Logger.new(File::NULL) # suppress logging
     end
   end
 

--- a/spec/hutch/tracers/datadog_spec.rb
+++ b/spec/hutch/tracers/datadog_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Hutch::Tracers::Datadog do
+  ::Datadog.logger.level = Logger::FATAL # suppress logging
+  
   describe "#handle" do
     subject(:handle) { tracer.handle(message) }
 


### PR DESCRIPTION
## Problem

![Screenshot from 2024-08-25 20-57-02](https://github.com/user-attachments/assets/24de7875-8fa1-4d2a-9d5e-ef5bfff276eb)

Tests fail and contain a noise in the output. [Example](https://github.com/sharshenov/hutch/actions/runs/10546690158/job/29218477784#step:6:63)

## Solution

This PR contains a few changes to fix the CI
- Fixes specs broken in https://github.com/ruby-amqp/hutch/pull/395
- Adds specs to test the change by https://github.com/ruby-amqp/hutch/pull/395
- Adds Rubies 3.1 and 3.2 to the test matrix
- Allows GithubActions to run on any branch besides `master` (by the way the main branch in the repo is `main`, not `master`)
- Silences loggers of Bugsnag and Datalog to keep the Rspec output clean