### PR TITLE
Take the minor version of Ruby into account

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: 
-          - 2.7
-          - 3.0
-          - 3.1
-          - 3.2
-          - 3.3
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The numeric version `3.0` is treated as `3`. As result, the latest Ruby 3.x version is used for testing instead of Ruby 3.0.
![Screenshot from 2024-08-26 09-31-39](https://github.com/user-attachments/assets/f787afb9-fe12-4522-9c2b-c50a8a463f55)


Using the text notation `'3.0'` makes Github Action to use the proper version for testing (Ruby 3.0)
![Screenshot from 2024-08-26 09-34-48](https://github.com/user-attachments/assets/48b4215d-7451-41c9-be1f-ff674359e104)
