### PR TITLE
Relax activesupport dependency to support rails 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: 
+        ruby-version:
           - '2.7'
           - '3.0'
           - '3.1'
@@ -30,7 +30,7 @@ jobs:
           - '3.3'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   end
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.15'
-  gem.add_runtime_dependency 'activesupport', '>= 4.2', '< 8'
+  gem.add_runtime_dependency 'activesupport', '>= 4.2', '<= 8'
 
   gem.name = 'hutch'
   gem.summary = 'Opinionated asynchronous inter-service communication using RabbitMQ'


### PR DESCRIPTION
In addition, upgrade the GH actions checkout dependency to the latest so it runs on supported version of node