### PR TITLE
Remove upper dependency version limit on activesupport

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   end
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.15'
-  gem.add_runtime_dependency 'activesupport', '>= 4.2', '<= 8'
+  gem.add_runtime_dependency 'activesupport', '>= 4.2'
 
   gem.name = 'hutch'
   gem.summary = 'Opinionated asynchronous inter-service communication using RabbitMQ'


### PR DESCRIPTION
With the release of Rails 8.0.0.1 the dependency update I made as part of https://github.com/ruby-amqp/hutch/pull/402 is too strict and the gem gets downgraded to version 0.23.1 as part of a rails upgrade

It might be better to remove the upper ceiling on `activesupport` so this doesn't become a recurring blocker for future rails releases