### PR TITLE
Make `ostruct` an explicit dependency

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.15'
   gem.add_runtime_dependency 'activesupport', '>= 4.2'
+  gem.add_runtime_dependency 'ostruct', '~> 0.6'
 
   gem.name = 'hutch'
   gem.summary = 'Opinionated asynchronous inter-service communication using RabbitMQ'

--- a/lib/hutch/version.rb
+++ b/lib/hutch/version.rb
@@ -1,3 +1,3 @@
 module Hutch
-  VERSION = '1.4.0.pre'.freeze
+  VERSION = '1.4.1.pre'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 require 'raven'
 require 'hutch'
 require 'logger'
+require 'ostruct'
 
 # set logger to be a null logger
 Hutch::Logging.logger = Logger.new(File::NULL)


### PR DESCRIPTION
Addresses the following raised issue: 
 - https://github.com/ruby-amqp/hutch/issues/406

ostruct is being removed as a default gem from Ruby 3.5+, see also:
 - https://github.com/ruby/ruby/pull/10428
 - https://github.com/rails/jbuilder/issues/561
 - https://github.com/mileszs/wicked_pdf/issues/1116