### PR TITLE
Add compatibility for ddtrace and datadog gems

### DIFF
--- a/lib/hutch/tracers/datadog.rb
+++ b/lib/hutch/tracers/datadog.rb
@@ -1,5 +1,10 @@
-require 'ddtrace'
-require 'ddtrace/auto_instrument'
+begin
+  require 'ddtrace'
+  require 'ddtrace/auto_instrument'
+rescue LoadError
+  require 'datadog'
+  require 'datadog/auto_instrument'
+end
 
 module Hutch
   module Tracers


### PR DESCRIPTION
From https://rubygems.org/gems/ddtrace
> NOTICE: This gem has been renamed to `datadog` since 2.0.0. Please use `datadog` instead of `ddtrace`. ddtrace is Datadog's tracing client for Ruby. It is used to trace requests as they flow across web servers, databases and microservices so that developers have great visiblity into bottlenecks and troublesome requests.

Add support for the new `datadog` gem.